### PR TITLE
Implement slide-out notifications panel

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -37,6 +37,7 @@
           --sidebar-width-expanded-percentage: 13%;
           --sidebar-actual-width-narrow: 70px;
           --search-panel-width: 397px;
+          --notifications-panel-width: 350px;
       }
 
       html, body {
@@ -198,8 +199,61 @@
         color: var(--primary-text-color);
         border-radius: 4px;
     }
-    #liveSearchResultsContainer ul#resultsListPanel li:hover { 
-        background-color: var(--general-hover-bg-color); 
+    #liveSearchResultsContainer ul#resultsListPanel li:hover {
+        background-color: var(--general-hover-bg-color);
+    }
+
+    /* Notification Panel */
+    .notifications-panel {
+        position: fixed;
+        top: 0;
+        left: var(--sidebar-width-expanded-percentage);
+        width: var(--notifications-panel-width);
+        height: 100vh;
+        background-color: var(--main-bg-color);
+        box-shadow: -2px 0 8px var(--divider-shadow-color);
+        z-index: 998;
+        display: flex;
+        flex-direction: column;
+        padding: 20px;
+        box-sizing: border-box;
+        transform: translateX(calc(100vw - var(--sidebar-width-expanded-percentage)));
+        transition: transform 0.35s ease-in-out;
+    }
+    .notifications-panel.active {
+        transform: translateX(0);
+    }
+    .notifications-panel-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 20px;
+    }
+    .notifications-panel-header h2 {
+        margin: 0;
+        font-size: 1.6rem;
+        font-weight: 600;
+        color: var(--primary-text-color);
+    }
+    .notifications-close {
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        cursor: pointer;
+        color: var(--secondary-text-color);
+    }
+    .notifications-close:hover {
+        color: var(--primary-text-color);
+    }
+    #notificationsList { list-style-type: none; padding: 0; margin: 0; }
+    #notificationsList li { padding: 10px 0; border-bottom: 1px solid var(--border-color); }
+    #notificationsList li:last-child { border-bottom: none; }
+
+    @media (max-width: 600px) {
+        .notifications-panel {
+            width: 100%;
+            left: 0;
+        }
     }
 
     /* General Link Styling */
@@ -225,27 +279,35 @@
     </div>
   </div>
 
-  <div id="searchPanel" class="search-panel">
-      <div class="search-panel-header">
-          <h2>Search</h2>
-      </div>
-      <div class="search-panel-input-container">
-          <input type="text" id="panelSearchInput" placeholder="Search">
-      </div>
-      <div class="search-panel-recents">
-          <div class="recents-header">
-              <strong>Recent</strong>
-              <button id="clearRecentsButton">Clear all</button>
-          </div>
-          <ul id="recentSearchesList">
-              <!-- This list will now be empty by default -->
-              <!-- Your JavaScript will populate this later with actual recent searches -->
-          </ul>
-      </div>
-      <div id="liveSearchResultsContainer">
-          <ul id="resultsListPanel"></ul> 
-      </div>
-  </div>
+    <div id="searchPanel" class="search-panel">
+        <div class="search-panel-header">
+            <h2>Search</h2>
+        </div>
+        <div class="search-panel-input-container">
+            <input type="text" id="panelSearchInput" placeholder="Search">
+        </div>
+        <div class="search-panel-recents">
+            <div class="recents-header">
+                <strong>Recent</strong>
+                <button id="clearRecentsButton">Clear all</button>
+            </div>
+            <ul id="recentSearchesList">
+                <!-- This list will now be empty by default -->
+                <!-- Your JavaScript will populate this later with actual recent searches -->
+            </ul>
+        </div>
+        <div id="liveSearchResultsContainer">
+            <ul id="resultsListPanel"></ul>
+        </div>
+    </div>
+
+    <div id="notificationsPanel" class="notifications-panel">
+        <div class="notifications-panel-header">
+            <h2>Notifications</h2>
+            <button id="closeNotificationsPanel" class="notifications-close">&times;</button>
+        </div>
+        <ul id="notificationsList"></ul>
+    </div>
 
 </body>
 </html>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -225,7 +225,7 @@
             </a>
         </li>
         <li>
-            <a href="{{ url_for('notifications_page') }}" class="{{ 'active' if active_page == 'notifications' else '' }}">
+            <a href="{{ url_for('notifications_page') }}" id="notificationsToggle" class="{{ 'active' if active_page == 'notifications' else '' }}">
                 <span class="sidebar-icon"><i class="bi bi-hearts"></i></span>
                 <span class="sidebar-label">
                     Notifications
@@ -264,7 +264,12 @@
     const recentsContainer = document.querySelector('.search-panel-recents');
     const recentSearchesUL = document.getElementById('recentSearchesList'); // Corrected ID
     const clearRecentsButton = document.getElementById('clearRecentsButton');
-    const liveSearchResultsContainer = document.getElementById('liveSearchResultsContainer');
+      const liveSearchResultsContainer = document.getElementById('liveSearchResultsContainer');
+
+      const notificationsToggle = document.getElementById('notificationsToggle');
+      const notificationsPanel = document.getElementById('notificationsPanel');
+      const closeNotificationsPanel = document.getElementById('closeNotificationsPanel');
+      const notificationsList = document.getElementById('notificationsList');
 
 
     const RECENT_SEARCHES_KEY = 'petAppRecentSearches';
@@ -399,22 +404,75 @@
         }
     }
 
-    function closeSearchPanel() {
-        if (mainSidebar) mainSidebar.classList.remove('narrow');
-        if (searchPanel) searchPanel.classList.remove('active');
-        if (searchIconToggle) searchIconToggle.classList.remove('active');
-    }
+      function closeSearchPanel() {
+          if (mainSidebar) mainSidebar.classList.remove('narrow');
+          if (searchPanel) searchPanel.classList.remove('active');
+          if (searchIconToggle) searchIconToggle.classList.remove('active');
+      }
 
-    if (searchIconToggle) {
-        searchIconToggle.addEventListener('click', function (event) {
-            event.stopPropagation();
-            if (searchPanel && searchPanel.classList.contains('active')) {
-                closeSearchPanel();
-            } else {
-                openSearchPanel();
-            }
-        });
-    }
+      function fetchNotifications() {
+          if (!notificationsList) return;
+          notificationsList.innerHTML = '<li>Loading...</li>';
+          fetch('/api/notifications')
+            .then(res => res.json())
+            .then(data => {
+                notificationsList.innerHTML = '';
+                if (data.length === 0) {
+                    notificationsList.innerHTML = '<li>No notifications.</li>';
+                } else {
+                    data.forEach(notif => {
+                        const li = document.createElement('li');
+                        const linkStart = notif.link && notif.link !== '#' ? `<a href="${notif.link}">` : '';
+                        const linkEnd = notif.link && notif.link !== '#' ? '</a>' : '';
+                        const time = notif.timestamp ? new Date(notif.timestamp).toLocaleString() : '';
+                        li.innerHTML = `${linkStart}${notif.message}${linkEnd}<br><small>${time}</small>`;
+                        notificationsList.appendChild(li);
+                    });
+                }
+            })
+            .catch(() => {
+                notificationsList.innerHTML = '<li>Error loading notifications.</li>';
+            });
+      }
+
+      function openNotificationsPanel() {
+          if (notificationsPanel) notificationsPanel.classList.add('active');
+          fetchNotifications();
+      }
+
+      function closeNotificationsPanelFn() {
+          if (notificationsPanel) notificationsPanel.classList.remove('active');
+      }
+
+      if (searchIconToggle) {
+          searchIconToggle.addEventListener('click', function (event) {
+              event.stopPropagation();
+              if (searchPanel && searchPanel.classList.contains('active')) {
+                  closeSearchPanel();
+              } else {
+                  openSearchPanel();
+              }
+          });
+      }
+
+      if (notificationsToggle) {
+          notificationsToggle.addEventListener('click', function(event) {
+              event.preventDefault();
+              event.stopPropagation();
+              if (notificationsPanel && notificationsPanel.classList.contains('active')) {
+                  closeNotificationsPanelFn();
+              } else {
+                  openNotificationsPanel();
+              }
+          });
+      }
+
+      if (closeNotificationsPanel) {
+          closeNotificationsPanel.addEventListener('click', function(event){
+              event.stopPropagation();
+              closeNotificationsPanelFn();
+          });
+      }
 
     document.addEventListener('click', function(event) {
         if (searchPanel && searchPanel.classList.contains('active')) {
@@ -422,6 +480,13 @@
             const isClickOnSearchIconToggle = searchIconToggle ? searchIconToggle.contains(event.target) : false;
             if (!isClickInsideSearchPanel && !isClickOnSearchIconToggle) {
                 closeSearchPanel();
+            }
+        }
+        if (notificationsPanel && notificationsPanel.classList.contains('active')) {
+            const insideNotif = notificationsPanel.contains(event.target);
+            const onToggle = notificationsToggle ? notificationsToggle.contains(event.target) : false;
+            if (!insideNotif && !onToggle) {
+                closeNotificationsPanelFn();
             }
         }
     });


### PR DESCRIPTION
## Summary
- add responsive notifications panel with smooth slide-out
- wire up notifications toggle in sidebar
- load notifications via new JSON endpoint
- tweak panel position to slide out from sidebar

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6840804f64a4832696f38a027d26e759