### PR TITLE
Move notifications panel next to sidebar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -207,17 +207,17 @@
     .notifications-panel {
         position: fixed;
         top: 0;
-        right: 0;
+        left: var(--sidebar-actual-width-narrow);
         width: var(--notifications-panel-width);
         height: 100vh;
         background-color: var(--main-bg-color);
-        box-shadow: -2px 0 8px var(--divider-shadow-color);
+        box-shadow: 2px 0 8px var(--divider-shadow-color);
         z-index: 998;
         display: flex;
         flex-direction: column;
         padding: 20px;
         box-sizing: border-box;
-        transform: translateX(100%);
+        transform: translateX(calc(-1 * var(--notifications-panel-width)));
         transition: transform 0.35s ease-in-out;
     }
     .notifications-panel.active {


### PR DESCRIPTION
## Summary
- adjust notifications panel styles so it slides in from just to the right of the sidebar

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68408a6e40c483269314c95a66320f91