### PR TITLE
Implement simple messaging

### DIFF
--- a/templates/direct_messages.html
+++ b/templates/direct_messages.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Edit Password | Pet App{% endblock %}
+{% block title %}Messages | Pet App{% endblock %}
 
 {% block content %}
 
@@ -8,7 +8,21 @@
 <h2>Conversation: {{ conversation_id }}</h2>
 <div id="chat-box">
     {% for message in messages %}
-        <p><b>{{ message.sender }}:</b> {{ message.text }} <i>{{ message.timestamp }}</i></p>
+        <p>
+            <strong>{{ message.sender_name }}</strong>:
+            {{ message.text }}
+            {% if message.edited %}<em>(edited)</em>{% endif %}
+            <small>{{ message.timestamp }}</small>
+            {% if session['user_uid'] == message.sender_uid %}
+                <form method="post" action="{{ url_for('delete_message', conversation_id=conversation_id, message_id=message.id) }}" style="display:inline">
+                    <button type="submit">Delete</button>
+                </form>
+                <form method="post" action="{{ url_for('edit_message', conversation_id=conversation_id, message_id=message.id) }}" style="display:inline">
+                    <input type="text" name="new_text" placeholder="Edit message" required>
+                    <button type="submit">Update</button>
+                </form>
+            {% endif %}
+        </p>
     {% endfor %}
 </div>
 <form method="post">

--- a/templates/messages_home.html
+++ b/templates/messages_home.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}Messages | Pet App{% endblock %}
+
+{% block content %}
+<h2>Start a Conversation</h2>
+<form method="get" action="{{ url_for('messages_home') }}">
+    <input type="text" name="q" placeholder="Search friends" value="{{ query|default('') }}">
+    <button type="submit">Search</button>
+</form>
+<ul>
+{% for friend in friends %}
+    <li><a href="{{ url_for('start_conversation', target_uid=friend.uid) }}">{{ friend.username }}</a></li>
+{% else %}
+    <li>No friends found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -238,7 +238,7 @@
                                     <button type="submit" class="btn-ig btn-ig-primary">Send Friend Request</button>
                                 </form>
                             {% endif %}
-                             <button type="button" class="btn-ig">Message</button> {# Keep your message button #}
+                             <a href="{{ url_for('start_conversation', target_uid=target_user_uid) }}" class="btn-ig">Message</a>
                         {% endif %}
                     </div>
                 </div>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -236,7 +236,7 @@
             </a>
         </li>
         <li>
-            <a href="{{ url_for('direct_messages', conversation_id='user1_user2') }}" class="{{ 'active' if active_page == 'direct_messages' else '' }}">
+            <a href="{{ url_for('messages_home') }}" class="{{ 'active' if active_page == 'messages' else '' }}">
                 <span class="sidebar-icon"><i class="bi bi-envelope-fill"></i></span>
                 <span class="sidebar-label">Messages</span>
             </a>


### PR DESCRIPTION
## Summary
- wire up conversation helper endpoints
- support editing and deleting messages
- add simple messages search page
- link messaging from profile and sidebar
- render editing controls in conversation template

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68409868a5888326a784a9d1a809953d