### PR TITLE
Add message badge and clear notifications

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -245,6 +245,17 @@
     .notifications-close:hover {
         color: var(--primary-text-color);
     }
+    .notifications-clear {
+        background: none;
+        border: none;
+        font-size: 0.9rem;
+        cursor: pointer;
+        color: var(--link-color);
+        margin-right: 10px;
+    }
+    .notifications-clear:hover {
+        color: var(--link-hover-color);
+    }
     #notificationsList { list-style-type: none; padding: 0; margin: 0; }
     #notificationsList li { padding: 10px 0; border-bottom: 1px solid var(--border-color); }
     #notificationsList li:last-child { border-bottom: none; }
@@ -301,7 +312,10 @@
     <div id="notificationsPanel" class="notifications-panel">
         <div class="notifications-panel-header">
             <h2>Notifications</h2>
-            <button id="closeNotificationsPanel" class="notifications-close">&times;</button>
+            <div>
+                <button id="clearNotificationsPanel" class="notifications-clear">Clear</button>
+                <button id="closeNotificationsPanel" class="notifications-close">&times;</button>
+            </div>
         </div>
         <ul id="notificationsList"></ul>
     </div>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -238,7 +238,12 @@
         <li>
             <a href="{{ url_for('messages_home') }}" class="{{ 'active' if active_page == 'messages' else '' }}">
                 <span class="sidebar-icon"><i class="bi bi-envelope-fill"></i></span>
-                <span class="sidebar-label">Messages</span>
+                <span class="sidebar-label">
+                    Messages
+                    {% if unread_message_count > 0 %}
+                        <span class="badge bg-danger ms-1">{{ unread_message_count }}</span>
+                    {% endif %}
+                </span>
             </a>
         </li>
         <li class="sidebar-dog-item">
@@ -266,10 +271,11 @@
     const clearRecentsButton = document.getElementById('clearRecentsButton');
       const liveSearchResultsContainer = document.getElementById('liveSearchResultsContainer');
 
-      const notificationsToggle = document.getElementById('notificationsToggle');
-      const notificationsPanel = document.getElementById('notificationsPanel');
-      const closeNotificationsPanel = document.getElementById('closeNotificationsPanel');
-      const notificationsList = document.getElementById('notificationsList');
+    const notificationsToggle = document.getElementById('notificationsToggle');
+    const notificationsPanel = document.getElementById('notificationsPanel');
+    const closeNotificationsPanel = document.getElementById('closeNotificationsPanel');
+    const clearNotificationsPanelBtn = document.getElementById('clearNotificationsPanel');
+    const notificationsList = document.getElementById('notificationsList');
 
 
     const RECENT_SEARCHES_KEY = 'petAppRecentSearches';
@@ -471,6 +477,17 @@
           closeNotificationsPanel.addEventListener('click', function(event){
               event.stopPropagation();
               closeNotificationsPanelFn();
+          });
+      }
+
+      if (clearNotificationsPanelBtn) {
+          clearNotificationsPanelBtn.addEventListener('click', function(event){
+              event.stopPropagation();
+              fetch('/mark_all_notifications_read', {method: 'POST'})
+                .then(() => { notificationsList.innerHTML = '<li>No notifications.</li>'; })
+                .catch(() => console.error('Failed to clear notifications'));
+              const badge = notificationsToggle ? notificationsToggle.querySelector('.badge') : null;
+              if (badge) badge.remove();
           });
       }
 


### PR DESCRIPTION
## Summary
- add unread message count to context processor
- create endpoint to mark all notifications as read
- generate message notifications and clear them on open
- show message badge in sidebar
- add clear button to notifications panel

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68409ae821b08326a5380ff31758c363