### PR TITLE
Fix clearing notifications badge without deleting notifications

### DIFF
--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -444,6 +444,13 @@
       function openNotificationsPanel() {
           if (notificationsPanel) notificationsPanel.classList.add('active');
           fetchNotifications();
+          // Mark notifications as read when panel is opened
+          fetch('/mark_all_notifications_read', {method: 'POST'})
+            .then(() => {
+                const badge = notificationsToggle ? notificationsToggle.querySelector('.badge') : null;
+                if (badge) badge.remove();
+            })
+            .catch(() => console.error('Failed to mark notifications as read'));
       }
 
       function closeNotificationsPanelFn() {


### PR DESCRIPTION
## Summary
- mark notifications as read when the panel opens
- remove the sidebar badge when opening the notifications panel

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68409dd1ecf883269caef5e96e1d2cd4