### PR TITLE
Add follower and following counts

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -247,8 +247,8 @@
 
                 <ul class="ig-info-row2-stats">
                     <li class="ig-stat-item"><span class="count">0</span> posts</li>
-                    <li class="ig-stat-item"><span class="count">0</span> followers</li>
-                    <li class="ig-stat-item"><span class="count">0</span> following</li>
+                    <li class="ig-stat-item"><span class="count">{{ user.followers_count|default(0) }}</span> followers</li>
+                    <li class="ig-stat-item"><span class="count">{{ user.following_count|default(0) }}</span> following</li>
                 </ul>
 
                 <div class="ig-info-row3-details">


### PR DESCRIPTION
## Summary
- extend signup user schema with follower/following counts
- update friend acceptance and unfriending to manage those counters
- read counts in `view_profile_page`
- render dynamic counts on profile page

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6840a784a30083269bb00d8320f29090