### PR TITLE
Add posts feature with engagement

### DIFF
--- a/templates/posts.html
+++ b/templates/posts.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block title %}Posts | Pet App{% endblock %}
+
+{% block content %}
+<div class="main-content">
+    <h2>Create Post</h2>
+    <form method="post" action="{{ url_for('create_post') }}" enctype="multipart/form-data">
+        <input type="file" name="image" required>
+        <input type="text" name="caption" placeholder="Caption">
+        <button type="submit">Upload</button>
+    </form>
+
+    <h2>Recent Posts</h2>
+    {% for post in posts %}
+    <div class="post" style="border:1px solid #ccc; padding:10px; margin-bottom:20px;">
+        <p><strong>{{ post.username }}</strong> - {{ post.timestamp }}</p>
+        <img src="{{ post.image_url }}" alt="post image" style="max-width:300px;">
+        <p>{{ post.caption }}</p>
+        <form method="post" action="{{ url_for('like_post', post_id=post.id) }}">
+            <button type="submit">{{ 'Unlike' if post.user_liked else 'Like' }} ({{ post.likes_count }})</button>
+        </form>
+        <div class="comments" style="margin-top:10px;">
+            {% for comment in post.comments %}
+            <div class="comment" style="margin-bottom:5px;">
+                <strong>{{ comment.username }}</strong>: {{ comment.text }}
+                <form method="post" action="{{ url_for('like_comment', post_id=post.id, comment_id=comment.id) }}" style="display:inline;">
+                    <button type="submit">{{ 'Unlike' if comment.user_liked else 'Like' }} ({{ comment.likes_count }})</button>
+                </form>
+            </div>
+            {% endfor %}
+            <form method="post" action="{{ url_for('add_comment', post_id=post.id) }}">
+                <input type="text" name="text" placeholder="Add a comment" required>
+                <button type="submit">Comment</button>
+            </form>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -213,6 +213,12 @@
                 <span class="sidebar-label">Home</span>
             </a>
         </li>
+        <li>
+            <a href="{{ url_for('posts_page') }}" class="{{ 'active' if active_page == 'posts' else '' }}">
+                <span class="sidebar-icon"><i class="bi bi-images"></i></span>
+                <span class="sidebar-label">Posts</span>
+            </a>
+        </li>
 
         <li class="search-toggle-item"> <a id="searchIconToggle"> <span class="sidebar-icon"><i class="bi bi-search"></i></span>
                 <span class="sidebar-label" id="searchIconToggleLabel">Search</span> </a>


### PR DESCRIPTION
## Summary
- implement posts feature with image upload, likes, and comments
- add routes for liking posts and comments
- create `posts.html` template for displaying posts
- link posts page from the sidebar

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6841a1c54ea483268d02c353e373bb87