### PR TITLE
Implement post deletion and add upload from home

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -9,6 +9,13 @@
     <div class="main-content">
         <h2>Home Page</h2>
         <p>Welcome to the Pet App! Find and share your favorite pet moments here.</p>
+
+        <h3>Create Post</h3>
+        <form method="post" action="{{ url_for('create_post') }}" enctype="multipart/form-data">
+            <input type="file" name="image" required>
+            <input type="text" name="caption" placeholder="Caption">
+            <button type="submit">Upload</button>
+        </form>
+
     </div>
-</div>
 {% endblock %}

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -20,6 +20,11 @@
         <form method="post" action="{{ url_for('like_post', post_id=post.id) }}">
             <button type="submit">{{ 'Unlike' if post.user_liked else 'Like' }} ({{ post.likes_count }})</button>
         </form>
+        {% if post.user_uid == session['user_uid'] %}
+        <form method="post" action="{{ url_for('delete_post', post_id=post.id) }}" style="display:inline;">
+            <button type="submit">Delete</button>
+        </form>
+        {% endif %}
         <div class="comments" style="margin-top:10px;">
             {% for comment in post.comments %}
             <div class="comment" style="margin-bottom:5px;">


### PR DESCRIPTION
## Summary
- allow deleting your own posts
- surface uploader for posts on the home page
- show Delete button on posts when viewing your post
- pass user uid to templates for authorization

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a4d5f0708326851e71a1ad427ca8