### PR TITLE
Enhance post photo upload

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -322,6 +322,45 @@
         -webkit-backdrop-filter: blur(8px);
         color: var(--primary-text-color);
     }
+
+    /* Hide the native file input */
+    .create-post-form .file-input-hidden {
+        display: none;
+    }
+
+    /* Custom drop area for file uploads */
+    .file-drop-area {
+        width: 100%;
+        padding: 25px 20px;
+        border-radius: 12px;
+        border: 2px dashed var(--glass-border-color);
+        background: rgba(255, 255, 255, 0.35);
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+        color: var(--secondary-text-color);
+        cursor: pointer;
+        transition: background 0.3s, transform 0.2s;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+    }
+    .file-drop-area i {
+        font-size: 2rem;
+        margin-bottom: 8px;
+        color: var(--secondary-text-color);
+    }
+    .file-drop-area:hover,
+    .file-drop-area.hover {
+        background: rgba(255, 255, 255, 0.5);
+        transform: translateY(-2px);
+    }
+    .file-drop-area img.preview {
+        max-width: 100%;
+        margin-top: 10px;
+        border-radius: 10px;
+        display: none;
+    }
     .create-post-form input[type="text"]::placeholder {
         color: var(--secondary-text-color);
     }

--- a/templates/home.html
+++ b/templates/home.html
@@ -10,7 +10,12 @@
         <div class="create-post-container glass-effect">
             <h3><i class="fa-solid fa-paw"></i> Create Post</h3>
             <form method="post" action="{{ url_for('create_post') }}" enctype="multipart/form-data" class="create-post-form">
-                <input type="file" name="image" required>
+                <div id="fileDropArea" class="file-drop-area">
+                    <i class="fa-solid fa-camera"></i>
+                    <span id="fileMsg">Upload a Pet Photo</span>
+                    <img id="filePreview" class="preview" alt="preview">
+                </div>
+                <input type="file" id="imageInput" name="image" class="file-input-hidden" accept="image/*" required>
                 <input type="text" name="caption" placeholder="Caption">
                 <button type="submit">Upload</button>
             </form>
@@ -48,4 +53,44 @@
         {% endfor %}
 
     </div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const dropArea = document.getElementById('fileDropArea');
+  const input = document.getElementById('imageInput');
+  const msg = document.getElementById('fileMsg');
+  const preview = document.getElementById('filePreview');
+
+  function handleFiles(files) {
+    if (!files.length) return;
+    const file = files[0];
+    msg.textContent = file.name;
+    if (file.type.startsWith('image/')) {
+      const reader = new FileReader();
+      reader.onload = e => {
+        preview.src = e.target.result;
+        preview.style.display = 'block';
+      };
+      reader.readAsDataURL(file);
+    } else {
+      preview.style.display = 'none';
+    }
+  }
+
+  dropArea.addEventListener('click', () => input.click());
+
+  ['dragenter','dragover'].forEach(evt => {
+    dropArea.addEventListener(evt, e => { e.preventDefault(); dropArea.classList.add('hover'); });
+  });
+  ['dragleave','drop'].forEach(evt => {
+    dropArea.addEventListener(evt, e => { e.preventDefault(); dropArea.classList.remove('hover'); });
+  });
+  dropArea.addEventListener('drop', e => {
+    if (e.dataTransfer.files.length) {
+      input.files = e.dataTransfer.files;
+      handleFiles(input.files);
+    }
+  });
+  input.addEventListener('change', () => handleFiles(input.files));
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- revamp the post file picker with a sleek glassmorphism design
- add JavaScript to preview images and support drag‑and‑drop

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6848cfa9f6188326a0de9dcff2dadc3c