### PR TITLE
Fix modal preview scaling

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -356,9 +356,11 @@
         }
         .file-drop-area img.preview {
             max-width: 100%;
+            max-height: 50vh; /* Prevent oversized previews */
             margin-top: 10px;
             border-radius: 10px;
             display: none;
+            object-fit: contain; /* Maintain aspect ratio without overflow */
         }
         .create-post-form input[type="text"]::placeholder {
             color: var(--secondary-text-color);


### PR DESCRIPTION
## Summary
- ensure preview images in the post modal never overflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849982a6b988326af0c0a991f31c1ad