### PR TITLE
Fix image sizing on home and profile

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -296,16 +296,18 @@
         .post {
             border: 1px solid var(--border-color);
             padding: 10px;
-            margin-bottom: 20px;
+            margin: 0 auto 20px;
             border-radius: 12px;
+            max-width: 500px;
         }
 
         .home-post-image {
             width: 100%;
-            height: auto;
+            height: 300px;
             display: block;
             margin-bottom: 10px;
-            object-fit: contain;
+            object-fit: cover;
+            border-radius: 8px;
         }
 
         .create-post-container {

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -221,8 +221,11 @@
     }
 
     .gallery-modal .modal-image {
-        max-width: 90%;
-        max-height: 90%;
+        width: 90%;
+        max-width: 600px;
+        max-height: 80vh;
+        border-radius: 12px;
+        object-fit: contain;
     }
 
     .gallery-modal .close {


### PR DESCRIPTION
## Summary
- limit post width and image height so feed images look like cards
- center profile gallery modal and limit full-size image dimensions

## Testing
- `python -m py_compile app.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499dc312d88326b4e04e5c0179c109