### PR TITLE
Improve post UI with modal, paw likes, delete options

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -301,6 +301,89 @@
             max-width: 500px;
         }
 
+        .post-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .post-time {
+            font-size: 0.9rem;
+            color: var(--secondary-text-color);
+        }
+
+        .like-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+        .like-btn .fa-paw {
+            color: var(--secondary-text-color);
+        }
+        .like-btn .fa-paw.liked {
+            color: red;
+        }
+
+        .post-options { position: relative; }
+        .options-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+        }
+        .options-menu {
+            position: absolute;
+            right: 0;
+            top: 20px;
+            background: var(--main-bg-color);
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            padding: 5px 10px;
+            display: none;
+        }
+        .options-menu.show { display: block; }
+
+        .comments {
+            margin-top: 10px;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+        .comment {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .comment-actions {
+            display: flex;
+            gap: 8px;
+        }
+
+        .delete-comment-btn,
+        .delete-post-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: var(--secondary-text-color);
+        }
+
+        .modal-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+            max-width: 800px;
+        }
+        .modal-image img {
+            width: 100%;
+            height: auto;
+            border-radius: 8px;
+        }
+        .modal-comments {
+            max-height: 80vh;
+            overflow-y: auto;
+        }
+
         .home-post-image {
             width: 100%;
             max-height: 600px;
@@ -563,6 +646,48 @@
                 });
             }
             if (input) input.addEventListener('change', () => handleFiles(input.files));
+
+            // Overflow menu toggle
+            document.querySelectorAll('.post-options').forEach(opts => {
+                const btn = opts.querySelector('.options-btn');
+                const menu = opts.querySelector('.options-menu');
+                if (btn && menu) {
+                    btn.addEventListener('click', e => {
+                        e.stopPropagation();
+                        menu.classList.toggle('show');
+                    });
+                }
+            });
+            document.addEventListener('click', () => {
+                document.querySelectorAll('.options-menu').forEach(m => m.classList.remove('show'));
+            });
+
+            // Confirm delete post/comment
+            document.querySelectorAll('.delete-post-form, .delete-comment-form').forEach(form => {
+                form.addEventListener('submit', e => {
+                    if (!confirm('Are you sure you want to delete?')) {
+                        e.preventDefault();
+                    }
+                });
+            });
+
+            // View post modal
+            const viewModal = document.getElementById('viewPostModal');
+            const closeView = document.getElementById('closeViewPost');
+            document.querySelectorAll('.post').forEach(card => {
+                card.addEventListener('click', e => {
+                    if (e.target.closest('button') || e.target.closest('form') || e.target.closest('.options-menu')) return;
+                    const imgSrc = card.querySelector('.home-post-image').src;
+                    const comments = card.querySelector('.comments').innerHTML;
+                    viewModal.querySelector('.modal-image img').src = imgSrc;
+                    viewModal.querySelector('.modal-comments').innerHTML = comments;
+                    viewModal.style.display = 'flex';
+                });
+            });
+            if (closeView) closeView.addEventListener('click', () => viewModal.style.display = 'none');
+            if (viewModal) viewModal.addEventListener('click', e => {
+                if (e.target === viewModal) viewModal.style.display = 'none';
+            });
         });
         </script>
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -4,37 +4,72 @@
 
 {% block content %}
     <div class="main-content">
-
         {% for post in posts %}
-        <div class="post glass-effect">
-            <p><strong>{{ post.username }}</strong> - {{ post.timestamp }}</p>
+        <div class="post glass-effect" data-post-id="{{ post.id }}">
+            <div class="post-header">
+                <strong>{{ post.username }}</strong>
+                <span class="post-time">{{ post.timestamp }}</span>
+                {% if post.user_uid == session['user_uid'] %}
+                <div class="post-options">
+                    <button class="options-btn"><i class="fa-solid fa-ellipsis"></i></button>
+                    <div class="options-menu">
+                        <form method="post" action="{{ url_for('delete_post', post_id=post.id) }}" class="delete-post-form">
+                            <button type="submit" class="delete-post-btn">Delete</button>
+                        </form>
+                    </div>
+                </div>
+                {% endif %}
+            </div>
             <img src="{{ post.image_url }}" alt="post image" class="home-post-image">
             <p>{{ post.caption }}</p>
-            <form method="post" action="{{ url_for('like_post', post_id=post.id) }}">
-                <button type="submit">{{ 'Unlike' if post.user_liked else 'Like' }} ({{ post.likes_count }})</button>
+            <form method="post" action="{{ url_for('like_post', post_id=post.id) }}" class="like-form">
+                <button type="submit" class="like-btn">
+                    {% if post.user_liked %}
+                    <i class="fa-solid fa-paw liked"></i>
+                    {% else %}
+                    <i class="fa-regular fa-paw"></i>
+                    {% endif %}
+                    <span class="like-count">{{ post.likes_count }}</span>
+                </button>
             </form>
-            {% if post.user_uid == session['user_uid'] %}
-            <form method="post" action="{{ url_for('delete_post', post_id=post.id) }}" style="display:inline;">
-                <button type="submit">Delete</button>
-            </form>
-            {% endif %}
-            <div class="comments" style="margin-top:10px;">
+            <div class="comments">
                 {% for comment in post.comments %}
-                <div class="comment" style="margin-bottom:5px;">
-                    <strong>{{ comment.username }}</strong>: {{ comment.text }}
-                    <form method="post" action="{{ url_for('like_comment', post_id=post.id, comment_id=comment.id) }}" style="display:inline;">
-                        <button type="submit">{{ 'Unlike' if comment.user_liked else 'Like' }} ({{ comment.likes_count }})</button>
-                    </form>
+                <div class="comment">
+                    <span class="comment-text"><strong>{{ comment.username }}</strong>: {{ comment.text }}</span>
+                    <div class="comment-actions">
+                        <form method="post" action="{{ url_for('like_comment', post_id=post.id, comment_id=comment.id) }}" class="comment-like-form">
+                            <button type="submit" class="like-btn">
+                                {% if comment.user_liked %}
+                                <i class="fa-solid fa-paw liked"></i>
+                                {% else %}
+                                <i class="fa-regular fa-paw"></i>
+                                {% endif %}
+                                <span class="like-count">{{ comment.likes_count }}</span>
+                            </button>
+                        </form>
+                        {% if comment.user_uid == session['user_uid'] %}
+                        <form method="post" action="{{ url_for('delete_comment', post_id=post.id, comment_id=comment.id) }}" class="delete-comment-form">
+                            <button type="submit" class="delete-comment-btn"><i class="fa-solid fa-trash"></i></button>
+                        </form>
+                        {% endif %}
+                    </div>
                 </div>
                 {% endfor %}
-                <form method="post" action="{{ url_for('add_comment', post_id=post.id) }}">
+                <form method="post" action="{{ url_for('add_comment', post_id=post.id) }}" class="add-comment-form">
                     <input type="text" name="text" placeholder="Add a comment" required>
                     <button type="submit">Comment</button>
                 </form>
             </div>
         </div>
         {% endfor %}
+    </div>
 
+    <div id="viewPostModal" class="post-modal view-post-modal">
+        <div class="modal-content glass-effect modal-grid">
+            <button class="modal-close" id="closeViewPost">&times;</button>
+            <div class="modal-image"><img src="" alt="post image"></div>
+            <div class="modal-comments"></div>
+        </div>
     </div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- format post timestamps for readability
- allow comment deletion and display who owns comments
- add paw like icons and overflow menu for delete
- show posts in modal on click and update CSS/JS

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b618e8a08326babe929fd7234b23