### PR TITLE
Add profile images and comment likes

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,6 +64,19 @@ def get_username(user_uid):
         print(f"Error fetching username for {user_uid}: {e}")
     return 'Unknown User'
 
+def get_profile_image(user_uid):
+    """Return the user's profile image or a default placeholder."""
+    default_img = url_for('static', filename='images/default_avatar.png')
+    if not user_uid:
+        return default_img
+    try:
+        user_doc = db_firestore.collection('users').document(user_uid).get()
+        if user_doc.exists:
+            return user_doc.to_dict().get('profile_image', default_img)
+    except Exception as e:
+        print(f"Error fetching profile image for {user_uid}: {e}")
+    return default_img
+
 # --- Your existing routes (home, profile, edit_profile, etc. 그대로 유지) ---
 # view_profile_page now includes follow_status logic
 @app.route("/")
@@ -84,6 +97,7 @@ def home():
                 'id': c_doc.id,
                 'user_uid': c_data.get('user_uid'),
                 'username': get_username(c_data.get('user_uid')),
+                'profile_image': get_profile_image(c_data.get('user_uid')),
                 'text': c_data.get('text'),
                 'likes_count': len(c_data.get('likes', [])),
                 'user_liked': user_uid in c_data.get('likes', [])
@@ -96,6 +110,7 @@ def home():
         posts.append({
             'id': p_doc.id,
             'username': get_username(p_data.get('user_uid')),
+            'profile_image': get_profile_image(p_data.get('user_uid')),
             'user_uid': p_data.get('user_uid'),
             'image_url': p_data.get('image_url'),
             'caption': p_data.get('caption'),
@@ -182,6 +197,7 @@ def view_profile_page(view_username):
                 comments.append({
                     'id': c_doc.id,
                     'username': get_username(c_data.get('user_uid')),
+                    'profile_image': get_profile_image(c_data.get('user_uid')),
                     'text': c_data.get('text'),
                     'likes_count': len(c_data.get('likes', [])),
                     'user_liked': logged_in_user_uid in c_data.get('likes', [])
@@ -189,6 +205,7 @@ def view_profile_page(view_username):
             posts.append({
                 'id': p_doc.id,
                 'username': get_username(p_data.get('user_uid')),
+                'profile_image': get_profile_image(p_data.get('user_uid')),
                 'user_uid': p_data.get('user_uid'),
                 'image_url': p_data.get('image_url'),
                 'caption': p_data.get('caption'),

--- a/templates/base.html
+++ b/templates/base.html
@@ -306,6 +306,17 @@
             justify-content: space-between;
             align-items: center;
         }
+        .post-user {
+            display: flex;
+            align-items: center;
+        }
+        .post-avatar {
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            object-fit: cover;
+            margin-right: 8px;
+        }
         .post-time {
             font-size: 0.9rem;
             color: var(--secondary-text-color);
@@ -407,6 +418,14 @@
         .modal-comments {
             max-height: 80vh;
             overflow-y: auto;
+        }
+        .modal-comments h3 {
+            margin-top: 0;
+        }
+        .comments-list {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
         }
 
         .home-post-image {
@@ -708,7 +727,8 @@
                 const commentsTemplate = card.querySelector('.comments-template');
                 const comments = commentsTemplate ? commentsTemplate.innerHTML : '<div>No comments yet.</div>';
                 viewModal.querySelector('.modal-image img').src = imgSrc;
-                viewModal.querySelector('.modal-comments').innerHTML = comments;
+                const list = viewModal.querySelector('.modal-comments .comments-list');
+                if (list) list.innerHTML = comments;
                 viewModal.style.display = 'flex';
             }
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -7,8 +7,10 @@
         {% for post in posts %}
         <div class="post glass-effect" data-post-id="{{ post.id }}">
             <div class="post-header">
-                <strong>{{ post.username }}</strong>
-                <span class="post-time">{{ post.timestamp }}</span>
+                <div class="post-user">
+                    <img src="{{ post.profile_image }}" alt="{{ post.username }}" class="post-avatar">
+                    <strong>{{ post.username }}</strong>
+                </div>
                 {% if post.user_uid == session['user_uid'] %}
                 <div class="post-options">
                     <button class="options-btn"><i class="fa-solid fa-ellipsis"></i></button>
@@ -40,8 +42,23 @@
                 {% for comment in post.comments %}
                 <div class="comment">
                     <span class="comment-text"><strong>{{ comment.username }}</strong>: {{ comment.text }}</span>
+                    <div class="comment-actions">
+                        <form method="post" action="{{ url_for('like_comment', post_id=post.id, comment_id=comment.id) }}" class="like-form">
+                            <button type="submit" class="like-btn">
+                                {% if comment.user_liked %}
+                                <i class="fa-solid fa-paw liked"></i>
+                                {% else %}
+                                <i class="fa-regular fa-paw"></i>
+                                {% endif %}
+                                <span class="like-count">{{ comment.likes_count }}</span>
+                            </button>
+                        </form>
+                    </div>
                 </div>
                 {% endfor %}
+                {% if post.comments|length == 0 %}
+                <div>No comments yet.</div>
+                {% endif %}
             </template>
 
             <a href="#" class="view-comments-link">View all {{ post.comments|length }} comments to the post</a>
@@ -53,7 +70,10 @@
         <div class="modal-content glass-effect modal-grid">
             <button class="modal-close" id="closeViewPost">&times;</button>
             <div class="modal-image"><img src="" alt="post image"></div>
-            <div class="modal-comments"></div>
+            <div class="modal-comments">
+                <h3>Comments</h3>
+                <div class="comments-list"></div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- fetch and provide user profile images for posts and comments
- display profile image beside username on posts
- remove timestamp from post header
- show comments with like buttons in modal
- style new avatar and comments section

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6849c6e8405883269fe4c0dddc983f6a