### PR TITLE
Add comment posting capability

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -396,6 +396,26 @@
             gap: 8px;
         }
 
+        .add-comment-form {
+            display: flex;
+            gap: 8px;
+            margin-top: 8px;
+        }
+        .add-comment-form input[type="text"] {
+            flex: 1;
+            padding: 6px 10px;
+            border: 1px solid var(--glass-border-color);
+            border-radius: 8px;
+        }
+        .add-comment-form button {
+            padding: 6px 12px;
+            border: none;
+            border-radius: 8px;
+            background: var(--link-color);
+            color: #fff;
+            cursor: pointer;
+        }
+
         .delete-comment-btn,
         .delete-post-btn {
             background: none;
@@ -726,9 +746,12 @@
                 const imgSrc = card.querySelector('.home-post-image').src;
                 const commentsTemplate = card.querySelector('.comments-template');
                 const comments = commentsTemplate ? commentsTemplate.innerHTML : '<div>No comments yet.</div>';
+                const postId = card.dataset.postId;
                 viewModal.querySelector('.modal-image img').src = imgSrc;
                 const list = viewModal.querySelector('.modal-comments .comments-list');
                 if (list) list.innerHTML = comments;
+                const form = viewModal.querySelector('.modal-comment-form');
+                if (form) form.action = `/add_comment/${postId}`;
                 viewModal.style.display = 'flex';
             }
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -62,6 +62,10 @@
             </template>
 
             <a href="#" class="view-comments-link">View all {{ post.comments|length }} comments to the post</a>
+            <form method="post" action="{{ url_for('add_comment', post_id=post.id) }}" class="add-comment-form">
+                <input type="text" name="text" placeholder="Add a comment..." required>
+                <button type="submit">Post</button>
+            </form>
         </div>
         {% endfor %}
     </div>
@@ -73,6 +77,10 @@
             <div class="modal-comments">
                 <h3>Comments</h3>
                 <div class="comments-list"></div>
+                <form method="post" action="" class="add-comment-form modal-comment-form">
+                    <input type="text" name="text" placeholder="Add a comment..." required>
+                    <button type="submit">Post</button>
+                </form>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- allow posting comments from a post card or modal
- style comment form and set modal form action via JS

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849c86f541c8326a9e5120f8cb7d4d4