### PR TITLE
Improve mobile responsiveness of sidebar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -272,6 +272,12 @@
             .notifications-panel { width: 100%; }
         }
 
+        @media (max-width: 768px) {
+            .app-container { grid-template-columns: var(--sidebar-actual-width-narrow) 1fr; }
+            .search-panel,
+            .notifications-panel { left: var(--sidebar-actual-width-narrow); }
+        }
+
         /* General Link Styling */
         a {
             color: var(--link-color);

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -230,6 +230,47 @@
         text-align: center;
     }
 
+    /* Mobile responsiveness */
+    @media (max-width: 768px) {
+        .sidebar {
+            width: var(--sidebar-actual-width-narrow);
+        }
+        .sidebar .sidebar-label {
+            opacity: 0;
+            max-width: 0;
+            font-size: 0;
+            overflow: hidden;
+            margin-left: -10px;
+            padding: 0;
+            white-space: normal;
+        }
+        .sidebar .sidebar-title {
+            font-size: 1rem;
+            padding: 0 5px 10px 5px;
+            margin-bottom: 15px;
+            opacity: 0;
+            max-height: 0;
+            overflow: hidden;
+        }
+        .sidebar a#searchIconToggle,
+        .sidebar li a {
+            justify-content: center;
+            gap: 0;
+            padding-left: 5px;
+            padding-right: 5px;
+        }
+        .sidebar .sidebar-dog-item {
+            opacity: 0;
+            max-height: 0;
+            overflow: hidden;
+            padding: 0;
+            margin: 0;
+        }
+        .sidebar .sidebar-section-title {
+            display: none;
+        }
+    }
+
 </style>
 
 <div class="sidebar" id="mainSidebar"> <div class="sidebar-title">Pets</div>


### PR DESCRIPTION
## Summary
- add mobile CSS rules for sidebar
- shift main container and panels on small screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a31ba82688326b9f556d1c52c47db