### PR TITLE
Enable comment deletion for post owners

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -412,6 +412,12 @@
             display: flex;
             gap: 8px;
         }
+        .delete-comment-form {
+            display: none;
+        }
+        .comment.show-delete .delete-comment-form {
+            display: inline;
+        }
 
         .add-comment-form {
             display: flex;
@@ -608,7 +614,7 @@
 
     {% block head_extra %}{% endblock %}
 </head>
-    <body>
+    <body data-current-user="{{ session['user_uid'] }}">
         <div class="app-container">
             <div class="sidebar-column glass-effect">
             {% include "sidebar.html" %}
@@ -780,6 +786,15 @@
                 });
             }
 
+            function attachDeleteToggle(comment) {
+                comment.addEventListener('click', function(e) {
+                    if (e.target.closest('form')) return;
+                    comment.classList.toggle('show-delete');
+                });
+            }
+
+            document.querySelectorAll('.comment').forEach(attachDeleteToggle);
+
             // View post modal
             const viewModal = document.getElementById('viewPostModal');
             const closeView = document.getElementById('closeViewPost');
@@ -794,6 +809,7 @@
                 if (list) {
                     list.innerHTML = comments;
                     list.querySelectorAll('.like-form').forEach(attachLikeHandler);
+                    list.querySelectorAll('.comment').forEach(attachDeleteToggle);
                 }
                 const form = viewModal.querySelector('.modal-comment-form');
                 if (form) form.action = `/add_comment/${postId}`;

--- a/templates/home.html
+++ b/templates/home.html
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="main-content">
         {% for post in posts %}
-        <div class="post glass-effect" data-post-id="{{ post.id }}">
+        <div class="post glass-effect" data-post-id="{{ post.id }}" data-post-owner="{{ post.user_uid }}">
             <div class="post-header">
                 <div class="post-user">
                     <img src="{{ post.profile_image }}" alt="{{ post.username }}" class="post-avatar">
@@ -40,7 +40,7 @@
 
             <template class="comments-template">
                 {% for comment in post.comments %}
-                <div class="comment">
+                <div class="comment" data-comment-id="{{ comment.id }}" data-post-id="{{ post.id }}">
                     <span class="comment-text"><strong>{{ comment.username }}</strong>: {{ comment.text }}</span>
                     <div class="comment-actions">
                         <form method="post" action="{{ url_for('like_comment', post_id=post.id, comment_id=comment.id) }}" class="like-form">
@@ -53,6 +53,11 @@
                                 <span class="like-count">{{ comment.likes_count }}</span>
                             </button>
                         </form>
+                        {% if session['user_uid'] == comment.user_uid or session['user_uid'] == post.user_uid %}
+                        <form method="post" action="{{ url_for('delete_comment', post_id=post.id, comment_id=comment.id) }}" class="delete-comment-form">
+                            <button type="submit" class="delete-comment-btn">Delete</button>
+                        </form>
+                        {% endif %}
                     </div>
                 </div>
                 {% endfor %}
@@ -117,17 +122,20 @@ document.addEventListener('DOMContentLoaded', function() {
     document.querySelectorAll('.like-form').forEach(attachLikeHandler);
 
     function addCommentToDom(data) {
-        const commentHTML = `<div class="comment"><span class="comment-text"><strong>${data.username}</strong>: ${data.text}</span><div class="comment-actions"><form method="post" action="/like_comment/${data.post_id}/${data.comment_id}" class="like-form"><button type="submit" class="like-btn"><i class="fa-regular fa-paw"></i><span class="like-count">0</span></button></form></div></div>`;
+        const deleteHTML = `<form method="post" action="/delete_comment/${data.post_id}/${data.comment_id}" class="delete-comment-form"><button type="submit" class="delete-comment-btn">Delete</button></form>`;
+        const commentHTML = `<div class="comment" data-comment-id="${data.comment_id}" data-post-id="${data.post_id}"><span class="comment-text"><strong>${data.username}</strong>: ${data.text}</span><div class="comment-actions"><form method="post" action="/like_comment/${data.post_id}/${data.comment_id}" class="like-form"><button type="submit" class="like-btn"><i class="fa-regular fa-paw"></i><span class="like-count">0</span></button></form>${deleteHTML}</div></div>`;
         document.querySelectorAll(`[data-post-id="${data.post_id}"] .comments-template`).forEach(t => {
             t.insertAdjacentHTML('beforeend', commentHTML);
             const newForm = t.lastElementChild.querySelector('.like-form');
             if (newForm) attachLikeHandler(newForm);
+            attachDeleteToggle(t.lastElementChild);
         });
         const modalList = document.querySelector('.modal-comments .comments-list');
         if (modalList && document.getElementById('viewPostModal').style.display === 'flex') {
             modalList.insertAdjacentHTML('beforeend', commentHTML);
             const newForm = modalList.lastElementChild.querySelector('.like-form');
             if (newForm) attachLikeHandler(newForm);
+            attachDeleteToggle(modalList.lastElementChild);
         }
     }
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -281,11 +281,11 @@
         {% if posts %}
         <div class="profile-gallery">
             {% for post in posts %}
-            <div class="post profile-post" data-post-id="{{ post.id }}">
+            <div class="post profile-post" data-post-id="{{ post.id }}" data-post-owner="{{ post.user_uid }}">
                 <img src="{{ post.image_url }}" alt="post image" class="home-post-image profile-gallery-thumb">
                 <template class="comments-template">
                     {% for comment in post.comments %}
-                    <div class="comment">
+                    <div class="comment" data-comment-id="{{ comment.id }}" data-post-id="{{ post.id }}">
                         <span class="comment-text"><strong>{{ comment.username }}</strong>: {{ comment.text }}</span>
                         <div class="comment-actions">
                             <form method="post" action="{{ url_for('like_comment', post_id=post.id, comment_id=comment.id) }}" class="like-form">
@@ -298,6 +298,11 @@
                                     <span class="like-count">{{ comment.likes_count }}</span>
                                 </button>
                             </form>
+                            {% if session['user_uid'] == comment.user_uid or session['user_uid'] == post.user_uid %}
+                            <form method="post" action="{{ url_for('delete_comment', post_id=post.id, comment_id=comment.id) }}" class="delete-comment-form">
+                                <button type="submit" class="delete-comment-btn">Delete</button>
+                            </form>
+                            {% endif %}
                         </div>
                     </div>
                     {% endfor %}
@@ -351,17 +356,20 @@
             }
 
             function addCommentToDom(data) {
-                const commentHTML = `<div class="comment"><span class="comment-text"><strong>${data.username}</strong>: ${data.text}</span><div class="comment-actions"><form method="post" action="/like_comment/${data.post_id}/${data.comment_id}" class="like-form"><button type="submit" class="like-btn"><i class="fa-regular fa-paw"></i><span class="like-count">0</span></button></form></div></div>`;
+                const deleteHTML = `<form method="post" action="/delete_comment/${data.post_id}/${data.comment_id}" class="delete-comment-form"><button type="submit" class="delete-comment-btn">Delete</button></form>`;
+                const commentHTML = `<div class="comment" data-comment-id="${data.comment_id}" data-post-id="${data.post_id}"><span class="comment-text"><strong>${data.username}</strong>: ${data.text}</span><div class="comment-actions"><form method="post" action="/like_comment/${data.post_id}/${data.comment_id}" class="like-form"><button type="submit" class="like-btn"><i class="fa-regular fa-paw"></i><span class="like-count">0</span></button></form>${deleteHTML}</div></div>`;
                 document.querySelectorAll(`[data-post-id="${data.post_id}"] .comments-template`).forEach(t => {
                     t.insertAdjacentHTML('beforeend', commentHTML);
                     const newForm = t.lastElementChild.querySelector('.like-form');
                     if (newForm) attachLikeHandler(newForm);
+                    attachDeleteToggle(t.lastElementChild);
                 });
                 const modalList = document.querySelector('.modal-comments .comments-list');
                 if (modalList && document.getElementById('viewPostModal').style.display === 'flex') {
                     modalList.insertAdjacentHTML('beforeend', commentHTML);
                     const newForm = modalList.lastElementChild.querySelector('.like-form');
                     if (newForm) attachLikeHandler(newForm);
+                    attachDeleteToggle(modalList.lastElementChild);
                 }
             }
 


### PR DESCRIPTION
## Summary
- permit post owners to delete comments in addition to comment authors
- include user uid when returning new comments
- add delete-comment functionality in templates
- toggle delete button when clicking comments

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684c2f3cd3f88326bc01909c325a5e75